### PR TITLE
Add freenode IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to contribute.
 ### Other
 
 * [DigitalOcean reddit community](https://www.reddit.com/r/digital_ocean/)
+* [`##digitalocean` on freenode](https://webchat.freenode.net/)
 * [Engineering Code of Conduct](https://github.com/digitalocean/engineering-code-of-conduct)
 * [DigitalOcean User Scripts](https://github.com/digitalocean/do_user_scripts) - user data scripts to help provision apps on a Droplet.
 


### PR DESCRIPTION
This PR adds `##digitalocean` freenode channel to list of awesome resources.
Seems like a good place to chat with DO users and ask your questions so I think it can be added here.

cc @jonleibowitz 